### PR TITLE
Missed string.h in src/unix-echo-client.c

### DIFF
--- a/src/unix-echo-client.c
+++ b/src/unix-echo-client.c
@@ -4,6 +4,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <errno.h>
+#include <string.h>
 #include <sys/fcntl.h> // fcntl
 #include <unistd.h> // close
 


### PR DESCRIPTION
Please find a fix for unix-echo-client: string.h was missed.
